### PR TITLE
Refactor utilities and add unit tests

### DIFF
--- a/INTERNAL_DOC.md
+++ b/INTERNAL_DOC.md
@@ -1,0 +1,29 @@
+# Internal Documentation
+
+## Modules
+
+- `ai_discussion/utils.py` – helpers for text formatting. Contains `strip_markdown` to remove markdown markup and `format_history` which joins a list of messages.
+- `ai_discussion/discusser_base.py` – abstract base class for all discussers. Uses `format_history` for history handling.
+- `ai_discussion/discusser.py` – implementation using pluggable AI backends.
+- `ai_discussion/simple_discusser.py` – rule based discusser used for tests and simple interactions.
+- `ai_discussion/ai_backends.py` – contains `GeminiBackend` and `OpenAIBackend` classes for real API calls.
+- `ai_discussion/discussion.py` – high level routine `run_discussion` that coordinates a multi-agent discussion.
+
+## Tests
+
+The `tests/` directory contains unit tests using `pytest`:
+
+- `tests/test_utils.py` – covers markdown stripping and history formatting.
+- `tests/test_base.py` – verifies base helper `_format_discussion_history` via a dummy discusser.
+- `tests/test_discusser.py` – checks name transliteration for AI discussers.
+- `tests/test_simple_discusser.py` – exercises simple discusser consensus logic.
+
+All tests can be executed with `pytest`.
+
+## Improvements
+
+- Introduced `utils.py` with common helper functions.
+- Added type hints and Google style docstrings to public functions.
+- Refactored `run_discussion` for clarity with explicit parameters and documentation.
+- Added minimal unit test suite.
+

--- a/ai_discussion/discusser_base.py
+++ b/ai_discussion/discusser_base.py
@@ -4,6 +4,7 @@ import re
 from typing import List, Optional, Union
 
 from .ai_backends import AIBackend
+from .utils import format_history
 
 class BaseDiscusser(abc.ABC):
     """Abstract base class for discussers that participate in AI discussions.
@@ -64,6 +65,4 @@ class BaseDiscusser(abc.ABC):
         Returns:
             Formatted discussion text
         """
-        if isinstance(prompt, list):
-            return "\n".join(prompt)
-        return prompt 
+        return format_history(prompt)

--- a/ai_discussion/discussion.py
+++ b/ai_discussion/discussion.py
@@ -1,24 +1,40 @@
-from .discusser import Discusser    
+"""High level discussion routine used by the web application."""
+
+from __future__ import annotations
+
 import asyncio
 import json
-import os
 import logging
-import re
+import os
+from typing import Awaitable, Callable, Iterable, List, Optional, Tuple
 
-def strip_markdown(text):
-    # Удалить markdown-форматирование: **, *, _, `, >, #, ~~, и т.п.
-    text = re.sub(r'\*\*([^*]+)\*\*', r'\1', text)  # **bold**
-    text = re.sub(r'\*([^*]+)\*', r'\1', text)        # *italic*
-    text = re.sub(r'__([^_]+)__', r'\1', text)          # __bold__
-    text = re.sub(r'_([^_]+)_', r'\1', text)            # _italic_
-    text = re.sub(r'`([^`]+)`', r'\1', text)            # `code`
-    text = re.sub(r'~~([^~]+)~~', r'\1', text)          # ~~strikethrough~~
-    text = re.sub(r'^>\s?', '', text, flags=re.MULTILINE) # > quote
-    text = re.sub(r'^#+\s?', '', text, flags=re.MULTILINE) # # heading
-    text = re.sub(r'\[(.*?)\]\((.*?)\)', r'\1', text) # [text](url)
-    return text
+from .discusser import Discusser
+from .discusser_base import BaseDiscusser
+from .utils import strip_markdown
 
-async def run_discussion(participants, question: str, max_rounds: int = 50, send_callback=None, discussion_id=None, check_if_stopped=None):
+
+async def run_discussion(
+    participants: Iterable[BaseDiscusser],
+    question: str,
+    max_rounds: int = 50,
+    send_callback: Optional[Callable[[str], Awaitable[None]]] = None,
+    discussion_id: Optional[str] = None,
+    check_if_stopped: Optional[Callable[[str], Awaitable[bool]]] = None,
+) -> Tuple[Optional[str], List[str]]:
+    """Run a multi-turn discussion until consensus or timeout.
+
+    Args:
+        participants: Iterable of discusser instances participating in the talk.
+        question: Initial question asked by the user.
+        max_rounds: Maximum number of rounds to run.
+        send_callback: Optional coroutine used to send intermediate messages.
+        discussion_id: Identifier used when checking for early termination.
+        check_if_stopped: Callback returning ``True`` if the discussion should
+            stop early.
+
+    Returns:
+        A tuple with summary text (or ``None``) and the full discussion history.
+    """
     logging.info(f"Начало обсуждения: {question}")
     discussion_history = [f"Вопрос пользователя: {question}. Вы должны ответить на заданную тему за 150 сообщений. Контролируйте ваше обсуждение, чтобы прийти к общему ответу на тему за данной количеством сообщений."]
     consensus = False
@@ -88,4 +104,4 @@ async def run_discussion(participants, question: str, max_rounds: int = 50, send
     except Exception as e:
         summary = f"Ошибка при получении вывода: {e}"
     logging.info(f"Обсуждение завершено. Статус: {'остановлено досрочно' if is_stopped else 'завершено нормально'}")
-    return summary, discussion_history 
+    return summary, discussion_history

--- a/ai_discussion/utils.py
+++ b/ai_discussion/utils.py
@@ -1,0 +1,41 @@
+"""Utility functions for text processing and other helpers."""
+
+import re
+from typing import List, Union
+
+__all__ = ["strip_markdown", "format_history"]
+
+
+def strip_markdown(text: str) -> str:
+    """Remove basic Markdown formatting from text.
+
+    Args:
+        text: A string potentially containing Markdown markup.
+
+    Returns:
+        The text without Markdown syntax.
+    """
+    text = re.sub(r"\*\*([^*]+)\*\*", r"\1", text)
+    text = re.sub(r"\*([^*]+)\*", r"\1", text)
+    text = re.sub(r"__([^_]+)__", r"\1", text)
+    text = re.sub(r"_([^_]+)_", r"\1", text)
+    text = re.sub(r"`([^`]+)`", r"\1", text)
+    text = re.sub(r"~~([^~]+)~~", r"\1", text)
+    text = re.sub(r"^>\s?", "", text, flags=re.MULTILINE)
+    text = re.sub(r"^#+\s?", "", text, flags=re.MULTILINE)
+    text = re.sub(r"\[(.*?)\]\((.*?)\)", r"\1", text)
+    return text
+
+
+def format_history(prompt: Union[str, List[str]]) -> str:
+    """Format discussion history into a single string.
+
+    Args:
+        prompt: Either a single prompt or a list of discussion messages.
+
+    Returns:
+        Joined discussion history suitable for sending to a model.
+    """
+    if isinstance(prompt, list):
+        return "\n".join(prompt)
+    return prompt

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ autogen-ext[openai]>=0.5.6
 empyrebase
 channels==4.0.0
 
+pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,23 @@
+import pytest
+
+from ai_discussion.discusser_base import BaseDiscusser
+
+
+class DummyDiscusser(BaseDiscusser):
+    async def initialize(self) -> None:
+        pass
+
+    async def ask(self, prompt):
+        return 'ok'
+
+    async def ask_without_humanization(self, prompt, discussion_history=None):
+        return 'ok'
+
+    async def close(self) -> None:
+        pass
+
+
+def test_format_history_util():
+    d = DummyDiscusser('x')
+    assert d._format_discussion_history(['a', 'b']) == 'a\nb'
+    assert d._format_discussion_history('z') == 'z'

--- a/tests/test_discusser.py
+++ b/tests/test_discusser.py
@@ -1,0 +1,9 @@
+import pytest
+
+from ai_discussion.discusser import Discusser
+
+
+@pytest.mark.asyncio
+async def test_transliterate_name():
+    d = Discusser(api_key='key', context='ctx', name='Тест', model='m', backend_type='openai')
+    assert d.agent_name == 'Test'

--- a/tests/test_simple_discusser.py
+++ b/tests/test_simple_discusser.py
@@ -1,0 +1,12 @@
+import pytest
+
+from ai_discussion.simple_discusser import SimpleDiscusser
+
+
+@pytest.mark.asyncio
+async def test_consensus_cycle():
+    d = SimpleDiscusser(name='A')
+    # first three calls should return 'НЕТ...'
+    assert await d.ask_without_humanization('диалог закончен?') == 'НЕТ, нам нужно обсудить еще несколько аспектов.'
+    assert await d.ask_without_humanization('диалог закончен?') == 'НЕТ, нам нужно обсудить еще несколько аспектов.'
+    assert await d.ask_without_humanization('диалог закончен?') == 'ДА'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,17 @@
+import pytest
+
+from ai_discussion.utils import strip_markdown, format_history
+
+
+def test_strip_markdown():
+    text = '**bold** _italic_ [link](http://example.com)'
+    assert strip_markdown(text) == 'bold italic link'
+
+
+def test_format_history_list():
+    history = ['one', 'two', 'three']
+    assert format_history(history) == 'one\ntwo\nthree'
+
+
+def test_format_history_string():
+    assert format_history('hello') == 'hello'


### PR DESCRIPTION
## Summary
- add `utils.py` for shared helper functions
- refactor `run_discussion` with type hints and docs
- use new `format_history` in `BaseDiscusser`
- add unit tests for core helpers and discussers
- document modules and test suite in `INTERNAL_DOC.md`
- install `pytest` for testing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882533968288326ac450c2156bdc243